### PR TITLE
Support for multiple post types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _site
 .DS_Store
 .sass-cache
+.jekyll-cache

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,14 @@
 clean:
 	$(RM) -r _site/
 
-post:
-	docker run -p 4000:4000 --rm --volume="$(CURDIR):/srv/jekyll" -it jekyll/jekyll:latest rake post
+essay:
+	docker run -p 4000:4000 --rm --volume="$(CURDIR):/srv/jekyll" -it jekyll/jekyll:latest rake essay
+
+external:
+	docker run -p 4000:4000 --rm --volume="$(CURDIR):/srv/jekyll" -it jekyll/jekyll:latest rake external
+
+howto:
+	docker run -p 4000:4000 --rm --volume="$(CURDIR):/srv/jekyll" -it jekyll/jekyll:latest rake howto
 
 preview: clean
 	docker run -p 4000:4000 --rm --volume="$(CURDIR):/srv/jekyll" -it jekyll/jekyll:latest jekyll s --future

--- a/Rakefile
+++ b/Rakefile
@@ -9,8 +9,8 @@ def prompt(*args)
   gets
 end
 
-desc "Generate new post"
-task :post do
+desc "Generate new essay post"
+task :essay do
 
   puts 'Post title:'
   @name = STDIN.gets.chomp
@@ -28,6 +28,57 @@ task :post do
       file << "date: #{DATE} #{TIME} +02:00\n"
       file << "permalink: #{PERMALINK}#{@title}/\n"
       file << "description: \"\"\n"
+      file << "category: essay\n"
+      file << "---\n"
+    end
+  end
+end
+
+desc "Generate new link post"
+task :external do
+
+  puts 'Post title:'
+  @name = STDIN.gets.chomp
+
+  @title = @name.downcase.strip.gsub(' ', '-')
+  @file = "#{POST_DIR}/#{DATE}-#{@title}.markdown"
+
+  if File.exists?("#{file}")
+    raise 'file already exists'
+  else
+    File.open(@file, 'a+') do |file|
+      file << "---\n"
+      file << "layout: post\n"
+      file << "title: \"#{@name}\"\n"
+      file << "date: #{DATE} #{TIME} +02:00\n"
+      file << "permalink: #{PERMALINK}#{@title}/\n"
+      file << "category: external\n"
+      file << "link: \n"
+      file << "---\n"
+    end
+  end
+end
+
+desc "Generate new how-to post"
+task :howto do
+
+  puts 'Post title:'
+  @name = STDIN.gets.chomp
+
+  @title = @name.downcase.strip.gsub(' ', '-')
+  @file = "#{POST_DIR}/#{DATE}-#{@title}.markdown"
+
+  if File.exists?("#{file}")
+    raise 'file already exists'
+  else
+    File.open(@file, 'a+') do |file|
+      file << "---\n"
+      file << "layout: post\n"
+      file << "title: \"#{@name}\"\n"
+      file << "date: #{DATE} #{TIME} +02:00\n"
+      file << "permalink: #{PERMALINK}#{@title}/\n"
+      file << "description: \"\"\n"
+      file << "category: how-to\n"
       file << "---\n"
     end
   end

--- a/_pages/archive.html
+++ b/_pages/archive.html
@@ -13,8 +13,8 @@ permalink: /archive/
   {% endif %}
   <ul class="archive-list">
     <li>
-      <!-- <span class="post-meta">{{ post.date | date: "%B %d" }}</span> -->
       <a class="archive-title" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+      <span class="archive-meta">{{ post.category }} <a class="permalink" href="{{ post.url }}">&infin;</a></span>
       <section class="archive-excerpt">
           {% if post.description.size > 0 %}
             {{ post.description }}

--- a/_posts/2019-01-07-2019.markdown
+++ b/_posts/2019-01-07-2019.markdown
@@ -4,6 +4,7 @@ title: "2019"
 date: 2019-01-07 14:57:27 +02:00
 permalink: /post/:year/2019/
 description: "Guiding principles for the coming year."
+category: essay
 ---
 
 - Experiences over possessions

--- a/_posts/2019-01-08-seven.markdown
+++ b/_posts/2019-01-08-seven.markdown
@@ -4,6 +4,7 @@ title: "Seven"
 date: 2019-01-08 11:45:02 +02:00
 permalink: /post/:year/seven/
 description: "My iPhone 7 will serve me for many more years."
+category: essay
 ---
 
 When the iPhone X and 8 were released in 2017 I had to get a new phone. My 6S had been on the verge of breaking due to [battery issues](https://www.apple.com/support/iphone6s-unexpectedshutdown/) - I didn't trust it anymore. But, instead of getting the latest iPhone, I got myself a 7.

--- a/_posts/2019-01-09-access.markdown
+++ b/_posts/2019-01-09-access.markdown
@@ -4,6 +4,7 @@ title: "Access"
 date: 2019-01-09 10:47:15 +02:00
 permalink: /post/:year/access/
 description: "Your television is spying on you and nothing gets patched."
+category: essay
 ---
 
 I have known for a very long time that today's televisions are sending data back home at an unprecedented scale. Companies like Samsung make tv's so cheap, you have to be the product one way or the other. We have a Sony set running Android so it's bound to send data back too - it's in the nature of the software it's running. Even if we're not using the built-in OS it will know when I've selected the HDMI input for my Xbox, I'm sure.

--- a/_posts/2019-01-10-segue.markdown
+++ b/_posts/2019-01-10-segue.markdown
@@ -4,6 +4,7 @@ title: "Segue"
 date: 2019-01-10 08:00:00 +02:00
 permalink: /post/:year/segue/
 description: "Out with the old. I've been changing a lot about this website."
+category: essay
 ---
 
 For the past few years my website has been in a state of constant flux. I would change the design over and over, I would change course with my content, I would not post a single thing for months on end. Most of those issues existed because of one thing: lack of focus.

--- a/_posts/2019-01-28-purpose.markdown
+++ b/_posts/2019-01-28-purpose.markdown
@@ -4,6 +4,7 @@ title: "Purpose"
 date: 2019-01-28 10:17:53 +02:00
 permalink: /post/:year/purpose/
 description: "What I think minimalism is and isn't."
+category: essay
 ---
 
 Places like Reddit and Twitter are filled with people who practice their version of minimalism. The most prevalent method is to just have less of everything. Some groups of people even go so far as to think they can only have a fixed amount of things in their lives.

--- a/_posts/2019-04-02-opposite.markdown
+++ b/_posts/2019-04-02-opposite.markdown
@@ -4,6 +4,7 @@ title: "Opposite"
 date: 2019-04-02 09:48:20 +02:00
 permalink: /post/:year/opposite/
 description: "Why Openbook has a good chance of making social networks relevant again."
+category: essay
 ---
 
 I haven't been a very active participant on social networks for the past few years. My Facebook timeline has succumbed to advertisers and publishers all vying for my attention. I occasionally open the Facebook app and once again come to the conclusion that, in fact, I haven't missed a single post by an actual human being.

--- a/assets/css/theme.scss
+++ b/assets/css/theme.scss
@@ -40,6 +40,10 @@ a {
   color: #3A4145;
 }
 
+  a.permalink {
+    text-decoration: none;
+  }
+
 img {
   max-width: 100%;
 }
@@ -182,6 +186,16 @@ body {
 .archive-title {
   font-family: $header-font;
   font-weight: 700;
+  
+}
+
+.archive-meta {
+  margin: 1em 0 0 .5em;
+  font-family: $header-font;
+  font-size: 0.8em;
+  line-height: 2.2rem;
+  color: #9EABB3;
+  text-transform: uppercase;
 }
 
 .archive-excerpt {

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@ title: Home
 
       <article class="post">
           <header class="post-header">
-              <h2 class="post-title"><a href="{% if post.link %}{{ post.link }}{% else %}{{ post.url }}{% endif %}">{{ post.title }}</a>{% if post.link %}<span class="link-arrow"> &rarr;</span>{% endif %}</h2>
+              <h2 class="post-title"><a href="{% if post.link %}{{ post.link }}{% else %}{{ post.url }}{% endif %}">{{ post.title }}</a>{% if post.link %}<span class="link-arrow"> &#10132;</span>{% endif %}</h2>
           </header>
           <section class="post-excerpt">
               {% if post.description.size > 0 %}
@@ -29,11 +29,12 @@ title: Home
           </section>
           <footer class="post-meta">
               {% if post.categories.size > 0 %}
-                  {{ post.categories | array_to_sentence_string | prepend: 'on ' }}
+                  {{ post.categories | array_to_sentence_string | append: ' on ' }}
               {% endif %}
-              <time class="post-date" datetime="{{ post.date | date:"%Y-%m-%d" }}">
-                  {{ post.date | date_to_string }}
+              <time class="post-date" datetime="{{ post.date | date: '%B %d, %Y' }}">
+                  {{ post.date | date: '%B %d, %Y' }}
               </time>
+              <a class="permalink" href="{{ post.url }}">&infin;</a>
           </footer>
       </article>
 


### PR DESCRIPTION
Implemented multiple post types:

- essay: for long form writing
- external: for linked posts
- how-to: for short how-to articles

